### PR TITLE
Fix page build failures

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,18 +5,21 @@ language: sv-se
 
 author: "Erik Eng"
 email: mail@ptz0n.se
-github: ptz0n
-twitter: ptz0n
-dribbble: ptz0n
-google: "105380157389113696457"
-flattr:
-    user: ptz0n
-    language: sv_SE
-facebook:
-    app: "481444638550896"
-    posts: 5
-    width: 500
-    admins: "516158352"
+
+accounts:
+  github: ptz0n
+  twitter: ptz0n
+  dribbble: ptz0n
+  google: "105380157389113696457"
+  flattr:
+      user: ptz0n
+      language: sv_SE
+  facebook:
+      app: "481444638550896"
+      posts: 5
+      width: 500
+      admins: "516158352"
+
 analytics:
     profile: "33567818"
 

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -6,20 +6,20 @@
                 <ul>
                     <li>Engineer at <a href="http://tictail.com/">Tictail</a></li>
                     <li>Likes <a href="http://www.opendata.se/">open data</a></li>
-                    <li>Contributing to <a href="https://github.com/{{ site.github }}" rel="me">open source</a></li>
+                    <li>Contributing to <a href="https://github.com/{{ site.accounts.github }}" rel="me">open source</a></li>
                 </ul>
             {% else %}
                 <ul>
                     <li>Utvecklare på <a href="http://tictail.com/">Tictail</a></li>
                     <li>Gillar <a href="http://www.opendata.se/">öppen data</a></li>
-                    <li>Bidrar till <a href="https://github.com/{{ site.github }}" rel="me">öppen källkod</a></li>
+                    <li>Bidrar till <a href="https://github.com/{{ site.accounts.github }}" rel="me">öppen källkod</a></li>
                 </ul>
             {% endif %}
             <ul class="links">
-                <li><a href="https://twitter.com/{{ site.twitter }}" class="twitter" rel="me">Twitter</a></li>
-                <li><a href="https://github.com/{{ site.github }}" class="github" rel="me">Github</a></li>
-                <li><a href="http://dribbble.com/{{ site.dribbble }}" class="dribbble" rel="me">Dribbble</a></li>
-                <li><a href="https://plus.google.com/{{ site.google }}/" class="google" rel="me">Google Plus</a></li>
+                <li><a href="https://twitter.com/{{ site.accounts.twitter }}" class="twitter" rel="me">Twitter</a></li>
+                <li><a href="https://github.com/{{ site.accounts.github }}" class="github" rel="me">Github</a></li>
+                <li><a href="http://dribbble.com/{{ site.accounts.dribbble }}" class="dribbble" rel="me">Dribbble</a></li>
+                <li><a href="https://plus.google.com/{{ site.accounts.google }}/" class="google" rel="me">Google Plus</a></li>
             </ul>
         </div>
     </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,8 +16,8 @@
 
         <meta name="google-site-verification" content="34bUc_U6BAEE5duPq_ThKJJZ3HTK1GmI5XWHkQ5xr6k" />
 
-        <meta property="fb:admins" content="{{ site.facebook.admins }}"/>
-        <meta property="fb:app_id" content="{{ site.facebook.app }}" />
+        <meta property="fb:admins" content="{{ site.accounts.facebook.admins }}"/>
+        <meta property="fb:app_id" content="{{ site.accounts.facebook.app }}" />
         <meta property="og:type" content="article" />
         <meta property="og:title" content="{{ page.title }}" />
         {% if page.description %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -23,14 +23,14 @@ layout: default
         <aside>
             <p>
                 <a class="button flattr"
-                    href="https://flattr.com/submit/auto?user_id={{ site.flattr.user }}&url={{ site.url }}{{ page.url }}&title={% if page.header %}{{ page.header }}{% else %}{{ page.title }}{% endif %}&\description={{ page.description }}&language={{ site.flattr.language }}&\tags={{ page.tags | array_to_sentence_string }}">
+                    href="https://flattr.com/submit/auto?user_id={{ site.accounts.flattr.user }}&url={{ site.url }}{{ page.url }}&title={% if page.header %}{{ page.header }}{% else %}{{ page.title }}{% endif %}&\description={{ page.description }}&language={{ site.accounts.flattr.language }}&\tags={{ page.tags | array_to_sentence_string }}">
                     Flattr
                 </a>
             </p>
 
             <div class="fb-comments"
                 data-href="{{ site.url }}{{ page.url }}"
-                data-numposts="{{ site.facebook.posts }}"
+                data-numposts="{{ site.accounts.facebook.posts }}"
                 data-colorscheme="light"></div>
 
         </aside>


### PR DESCRIPTION
Hey Erik,

I think that this pull request will fix the page build failures on your site. To make a long story short, https://github.com/jekyll/jekyll-redirect-from/pull/26 and https://github.com/github/pages-gem/pull/88 were recently merged, and as a result the `jekyll-redirect-from` gem now makes the assumption that `site.github.url` will always be used as a redirect prefix. You had a different value for `site.github` in your __config.yml_, which likely confused the gem.

If this does indeed fix your problem and you're interested in discussing the effects of the recent changes further, check out https://github.com/jekyll/jekyll-redirect-from/issues/42.

Hope this helps! :heart: :octocat: 
